### PR TITLE
add rust_tls feature and replace native-tls in order to support Windows XP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +54,9 @@ dependencies = [
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustls 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.18.0-alpha4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki-roots 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -328,12 +340,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.13.0-alpha5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustls"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.13.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sct 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.18.0-alpha4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "safemem"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "schannel"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sct"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.13.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -437,6 +487,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "url"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +520,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "webpki"
+version = "0.18.0-alpha4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ring 0.13.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.18.0-alpha4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "winapi"
@@ -502,6 +575,7 @@ dependencies = [
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
+"checksum base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "85415d2594767338a74a30c1d370b2f3262ec1b4ed2d7bba5b3faf4de40467d9"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
@@ -540,7 +614,11 @@ dependencies = [
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum ring 0.13.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)" = "3845516753f91b4511f9b17c917ea6fa4bc5a7853a9947b0f66731aff51cdef5"
+"checksum rustls 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab72e4883a4fc9fd5cd462a51c55d79f6a7b5c9483e8d73a2b7bca0b18430bcd"
+"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "85fd9df495640643ad2d00443b3d78aae69802ad488debab4f1dd52fc1806ade"
+"checksum sct 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4540aed8d71a5de961a8902cf356e28122bd62695eb5be1c214f84d8704097c"
 "checksum security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfa44ee9c54ce5eecc9de7d5acbad112ee58755239381f687e564004ba4a2332"
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
@@ -554,11 +632,14 @@ dependencies = [
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum untrusted 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70afa43c8c5d23a53a3c39ec9b56232c5badc19f6bb5ad529c1d6448a7241365"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7ed0f6789c8a85ca41bbc1c9d175422116a9869bd1cf31bb08e1493ecce60380"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum webpki 0.18.0-alpha4 (registry+https://github.com/rust-lang/crates.io-index)" = "724897af4bb44f3e0142b9cca300eb15f61b9b34fa559440bed8c43f2ff7afc0"
+"checksum webpki-roots 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "edbd75d6abf044ef0c9d7ec92b9e8c518bcd93a15bb7bd9a92239e035248fc17"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,18 @@ description = "simple HTTP client"
 license = "MIT/Apache-2.0"
 keywords = ["http", "client"]
 
+[features]
+default = ["native-tls"]
+rust_tls = ["rustls", "webpki", "webpki-roots"]
+
 [dependencies]
 http-with-url = "0.2.0"
 httparse = "1.2.4"
 log = "0.4.1"
-native-tls = "0.1.5"
+native-tls = { version = "0.1.5", optional = true }
+rustls = { version = "0.12.0", optional = true }
+webpki = { version = "^0.18.0-alpha", optional = true }
+webpki-roots = { version = "^0.14.0", optional = true }
 
 [dev-dependencies]
 ansi_term = "0.11.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,7 +5,18 @@ use std::net::TcpStream;
 use http::{header, Method, Request, Response};
 use http::header::HeaderValue;
 use http::url::Origin;
+
+#[cfg(not(feature="rust_tls"))]
 use native_tls::{HandshakeError, TlsConnector, TlsStream};
+
+#[cfg(feature="rust_tls")]
+use rustls;
+#[cfg(feature="rust_tls")]
+use std::sync::Arc;
+#[cfg(feature="rust_tls")]
+use webpki;
+#[cfg(feature="rust_tls")]
+use webpki_roots;
 
 use body::{Body, FromBody, ToBody};
 use http1;
@@ -14,10 +25,16 @@ use util::{is_persistent_connection, is_redirect_method_get, is_redirect_status,
 /// A HTTP(S) client.
 ///
 /// Use `Client::new().fetch(request)` to make a single request.
+#[cfg(not(feature="rust_tls"))]
 pub struct Client {
     tcp_streams: HashMap<Origin, TcpStream>,
     tls_streams: HashMap<Origin, TlsStream<TcpStream>>,
     tls_connector: Option<TlsConnector>,
+}
+
+#[cfg(feature="rust_tls")]
+pub struct Client {
+    tcp_streams: HashMap<Origin, TcpStream>,
 }
 
 impl Client {
@@ -25,6 +42,7 @@ impl Client {
     ///
     /// Try to use a client for multiple connections as the client may
     /// be able to reuse existing connections.
+    #[cfg(not(feature="rust_tls"))]
     pub fn new() -> Client {
         Client {
             tcp_streams: HashMap::new(),
@@ -33,6 +51,14 @@ impl Client {
         }
     }
 
+    #[cfg(feature="rust_tls")]
+    pub fn new() -> Client {
+        Client {
+            tcp_streams: HashMap::new(),
+        }
+    }
+
+    #[cfg(not(feature="rust_tls"))]
     fn get_tls_connector(&mut self) -> io::Result<&TlsConnector> {
         if let Some(ref connector) = self.tls_connector {
             return Ok(connector);
@@ -144,6 +170,7 @@ impl Client {
         Ok(response)
     }
 
+    #[cfg(not(feature="rust_tls"))]
     fn fetch_network_https<A: ToBody, B: FromBody>(
         &mut self,
         request: &mut Request<A>,
@@ -175,6 +202,38 @@ impl Client {
         ) {
             debug!("Keeping secure connection to {:?} for later use", origin);
             self.tls_streams.insert(origin, tls_stream);
+        } else {
+            debug!("Closed secure connection to {:?}", origin);
+        }
+        Ok(response)
+    }
+
+    #[cfg(feature="rust_tls")]
+    fn fetch_network_https<A: ToBody, B: FromBody>(
+    &mut self,
+        request: &mut Request<A>,
+    ) -> io::Result<Response<B>> {
+        let origin = request.url().origin();
+                
+        let mut config = rustls::ClientConfig::new();
+        config.root_store.add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+
+        let mut sess_and_sock= {
+            let domain = request.url().domain().unwrap();
+            let dns_name = webpki::DNSNameRef::try_from_ascii_str(domain).unwrap();
+            let mut sess = rustls::ClientSession::new(&Arc::new(config), dns_name);
+            let mut sock = TcpStream::connect(format!("{}:443", domain)).unwrap();
+            (sess, sock)    
+        };
+        let mut tls_stream = rustls::Stream::new(&mut sess_and_sock.0, &mut sess_and_sock.1);
+        
+        let response = Client::fetch_data(request, &mut tls_stream)?;
+        if is_persistent_connection(
+            response.version(),
+            response.headers().get_all(header::CONNECTION),
+        ) {
+            debug!("Keeping secure connection to {:?} for later use", origin);
+           // self.tls_streams.insert(origin, tls_stream);
         } else {
             debug!("Closed secure connection to {:?}", origin);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,16 @@ extern crate http_with_url as http;
 extern crate httparse;
 #[macro_use]
 extern crate log;
+
+#[cfg(not(feature="rust_tls"))]
 extern crate native_tls;
+
+#[cfg(feature="rust_tls")]
+extern crate rustls;
+#[cfg(feature="rust_tls")]
+extern crate webpki;
+#[cfg(feature="rust_tls")]
+extern crate webpki_roots;
 
 pub use body::{Body, FromBody};
 pub use client::{Client, Error};


### PR DESCRIPTION
Add an optional feature "rust_tls" to replace native-tls by rustls in order to support Windows XP.

native-tls use SChannel and it's not available on Windows XP ^^